### PR TITLE
Changed anchorRouting initial state

### DIFF
--- a/excess-router-config.html
+++ b/excess-router-config.html
@@ -31,7 +31,7 @@ Examples:
        */
       anchorRouting: {
         type: Boolean,
-        value: true
+        value: false
       },
       /**
        * True if RouteManager starts on WebComponentsReady.


### PR DESCRIPTION
Since Polymer 1.0 the boolean attribute binding has changed:
https://www.polymer-project.org/1.0/docs/devguide/properties#attribute-deserialization

Boolean properties MUST be set to false initially. Otherwise it can never be set to false later. Here is the quote from the documentation:

"For a Boolean property to be configurable from markup, it must default to false. If it defaults to true, you cannot set it to false from markup, since the presence of the attribute, with or without a value, equates to true. This is the standard behavior for attributes in the web platform."